### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: File a bug report.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+> [!IMPORTANT]
+> **This repo is for Emochi, the macOS menu bar emoji picker.**
+>
+> If you're reporting an issue with Emochi (AI chat/roleplay app on iOS/Android),
+> please find their support center for help.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a GitHub bug report issue template including a prominent note clarifying this repo (macOS Emochi) vs the unrelated mobile app.
> 
> - **Repo meta / GitHub templates**:
>   - **New** `/.github/ISSUE_TEMPLATE/bug_report.md`:
>     - Provides structured sections (description, reproduction steps, expected behavior, screenshots, environment, additional context).
>     - Includes a prominent note clarifying this repo is for the macOS menu bar emoji picker, not the mobile Emochi app.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a867977a3b67416731170e5a6b03b198001a47c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->